### PR TITLE
Implement basic client-side PDF merge functionality

### DIFF
--- a/app/dashboard/pdf-merge/page.tsx
+++ b/app/dashboard/pdf-merge/page.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState } from 'react';
+import { PDFDocument } from 'pdf-lib';
+
+export default function PdfMergePage() {
+  const [files, setFiles] = useState<File[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const handleMerge = async () => {
+    if (files.length < 2) {
+      alert('Please select at least 2 PDF files');
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const mergedPdf = await PDFDocument.create();
+
+      for (const file of files) {
+        const bytes = await file.arrayBuffer();
+        const pdf = await PDFDocument.load(bytes);
+        const pages = await mergedPdf.copyPages(pdf, pdf.getPageIndices());
+        pages.forEach((page) => mergedPdf.addPage(page));
+      }
+
+      const mergedBytes = await mergedPdf.save();
+      const blob = new Blob([mergedBytes], { type: 'application/pdf' });
+      const url = URL.createObjectURL(blob);
+
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'merged.pdf';
+      a.click();
+
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error(err);
+      alert('Failed to merge PDFs');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>PDF Merge</h1>
+      <p>Select multiple PDF files to merge them into one.</p>
+
+      <input
+        type="file"
+        accept="application/pdf"
+        multiple
+        onChange={(e) => {
+          if (!e.target.files) return;
+          setFiles(Array.from(e.target.files));
+        }}
+      />
+
+      <p>{files.length} file(s) selected</p>
+
+      <button
+        onClick={handleMerge}
+        disabled={loading || files.length < 2}
+        style={{ marginTop: '1rem' }}
+      >
+        {loading ? 'Merging...' : 'Merge PDFs'}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## What was done
- Implemented a working client-side PDF merge tool
- Added a new `/dashboard/pdf-merge` page
- Allows users to select multiple PDF files and merge them offline
- Generates and downloads a merged PDF directly in the browser

## Why this change
- PDF Merge was listed in the UI but not functional
- This provides a minimum viable, privacy-first implementation
- Establishes a foundation for future PDF enhancements

## How it was tested
- Ran the app locally using `pnpm run dev`
- Selected multiple PDF files
- Verified merged PDF downloads correctly and contains all pages

## Related Issue
Closes #10
<img width="509" height="411" alt="Screenshot 2026-02-05 000349" src="https://github.com/user-attachments/assets/c45d2787-be13-4591-a224-4a39c33cb187" />
<img width="1569" height="731" alt="Screenshot 2026-02-05 000515" src="https://github.com/user-attachments/assets/e375ed22-0361-4a14-a618-80c5b8854db1" />
<img width="546" height="651" alt="Screenshot 2026-02-05 000527" src="https://github.com/user-attachments/assets/d9d6d26d-3fac-4246-92de-9f4708e98272" />
<img width="184" height="120" alt="Screenshot 2026-02-05 000558" src="https://github.com/user-attachments/assets/120ce0ee-2040-4b7d-b763-8397720fc49b" />
