### PR TITLE
Fix build failure caused by BlobPart type mismatch in PDF merge

### DIFF
--- a/app/dashboard/pdf-merge/page.tsx
+++ b/app/dashboard/pdf-merge/page.tsx
@@ -26,7 +26,12 @@ export default function PdfMergePage() {
       }
 
       const mergedBytes = await mergedPdf.save();
-      const blob = new Blob([mergedBytes], { type: 'application/pdf' });
+const blob = new Blob([new Uint8Array(mergedBytes)], {
+  type: 'application/pdf',
+});
+
+
+
       const url = URL.createObjectURL(blob);
 
       const a = document.createElement('a');


### PR DESCRIPTION
## Fixes build error (#14)

### Problem
`pnpm run build` failed due to a TypeScript type error in
`app/dashboard/pdf-merge/page.tsx` where `Uint8Array / ArrayBufferLike`
was not assignable to `BlobPart` during production build.

### Solution
- Avoided `ArrayBuffer` / `SharedArrayBuffer` union issues
- Passed a `Uint8Array` directly to `Blob`, which is a valid `BlobPart`
- No runtime behavior changes
- Fully compatible with Next.js 16 strict production build

### Result
- `pnpm run build` passes successfully
- PDF merge functionality remains unchanged

Closes #14
<img width="632" height="384" alt="Screenshot 2026-02-05 201520" src="https://github.com/user-attachments/assets/d3d00fbc-801d-4dff-9bd8-d1e4541aec97" />
