### PR TITLE
error is fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "framer-motion": "^12.29.0",
     "lucide-react": "^0.562.0",
     "next": "16.1.4",
+    "pdf-lib": "^1.17.1",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "tailwind-merge": "^3.4.0"


### PR DESCRIPTION
## What I changed
- Added missing `pdf-lib` dependency used in `app/dashboard/pdf-merge/page.tsx`

## Why this fixes the issue
- The build was failing due to a `module-not-found` error for `pdf-lib`
- Adding the dependency fixes the Next.js build error

## Verification
- `pnpm run build` now completes successfully
