### PR TITLE
Add drag-and-drop support to PDF Merge

### DIFF
--- a/app/dashboard/pdf-merge/page.tsx
+++ b/app/dashboard/pdf-merge/page.tsx
@@ -6,6 +6,29 @@ import { PDFDocument } from 'pdf-lib';
 export default function PdfMergePage() {
   const [files, setFiles] = useState<File[]>([]);
   const [loading, setLoading] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+
+const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+  e.preventDefault();
+  setIsDragging(true);
+};
+
+const handleDragLeave = () => {
+  setIsDragging(false);
+};
+
+const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+  e.preventDefault();
+  setIsDragging(false);
+
+  const droppedFiles = Array.from(e.dataTransfer.files).filter(
+    (file) => file.type === 'application/pdf'
+  );
+
+  if (droppedFiles.length === 0) return;
+
+  setFiles((prev) => [...prev, ...droppedFiles]);
+};
 
   const handleMerge = async () => {
     if (files.length < 2) {
@@ -49,9 +72,24 @@ const blob = new Blob([new Uint8Array(mergedBytes)], {
   };
 
   return (
-    <div style={{ padding: '2rem' }}>
+    <div
+  style={{
+    padding: '2rem',
+    border: isDragging ? '2px dashed #4f46e5' : '2px dashed #ccc',
+    backgroundColor: isDragging ? '#eef2ff' : 'transparent',
+    borderRadius: '8px',
+  }}
+  onDragOver={handleDragOver}
+  onDragLeave={handleDragLeave}
+  onDrop={handleDrop}
+>
+
       <h1>PDF Merge</h1>
       <p>Select multiple PDF files to merge them into one.</p>
+      <p style={{ color: '#666', marginTop: '0.5rem' }}>
+  Drag & drop PDF files here, or use the file picker below.
+</p>
+
 
       <input
         type="file"


### PR DESCRIPTION
## What this PR does
Adds drag-and-drop support to the PDF Merge tool, allowing users to add PDF files by dragging them directly into the merge area.

## Why this change is needed
Previously, users could only add PDFs using the file picker. Drag-and-drop improves usability and aligns with modern document tool UX expectations.

## How it works
- Introduces a visual drop zone with drag state feedback
- Filters dropped files to accept PDFs only
- Reuses existing merge logic without changes

<img width="1865" height="937" alt="Screenshot 2026-02-06 002005" src="https://github.com/user-attachments/assets/812669ff-8823-4edb-8c98-8c9c2cd6924a" />
## Issue
Closes #21
