### PR TITLE
bug is fixed(preserve previously selected files)

### DIFF
--- a/app/dashboard/pdf-merge/page.tsx
+++ b/app/dashboard/pdf-merge/page.tsx
@@ -97,7 +97,7 @@ const blob = new Blob([new Uint8Array(mergedBytes)], {
         multiple
         onChange={(e) => {
           if (!e.target.files) return;
-          setFiles(Array.from(e.target.files));
+          setFiles((prev) => [...prev, ...Array.from(e.target.files!)]);
         }}
       />
 


### PR DESCRIPTION
## Problem
Previously selected files disappeared when selecting additional files in PDF Merge.

## Fix
Updated file selection logic to append new files instead of replacing existing ones.

## Result
Users can now select files incrementally without losing previous selections.

Fixes #24
<img width="1855" height="938" alt="Screenshot 2026-02-06 193023" src="https://github.com/user-attachments/assets/57d6a229-1d0a-4811-8124-33c66964f38d" />
