### PR TITLE
Fix: Show selected PDF files and add drag-and-drop reorder UI in PDF Merge

### DIFF
--- a/app/dashboard/pdf-merge/page.tsx
+++ b/app/dashboard/pdf-merge/page.tsx
@@ -7,6 +7,15 @@ export default function PdfMergePage() {
   const [files, setFiles] = useState<File[]>([]);
   const [loading, setLoading] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+
+const moveFile = (from: number, to: number) => {
+  const updated = [...files];
+  const [moved] = updated.splice(from, 1);
+  updated.splice(to, 0, moved);
+  setFiles(updated);
+};
+
 
 const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
   e.preventDefault();
@@ -102,6 +111,30 @@ const blob = new Blob([new Uint8Array(mergedBytes)], {
       />
 
       <p>{files.length} file(s) selected</p>
+      {files.map((file, index) => (
+  <div
+    key={index}
+    draggable
+    onDragStart={() => setDragIndex(index)}
+    onDragOver={(e) => e.preventDefault()}
+    onDrop={() => {
+      if (dragIndex === null) return;
+      moveFile(dragIndex, index);
+      setDragIndex(null);
+    }}
+    style={{
+      padding: "8px",
+      marginTop: "5px",
+      border: "1px solid gray",
+      borderRadius: "5px",
+      backgroundColor: "#f0f0f0",
+      cursor: "grab",
+    }}
+  >
+    📄 {file.name}
+  </div>
+))}
+
 
       <button
         onClick={handleMerge}


### PR DESCRIPTION
## Summary
Fixes Issue #26 by displaying selected PDF files and enabling drag-and-drop reordering in the PDF Merge tool.

## Changes
- Show list of selected PDF files
- Add drag-and-drop reorder functionality
- Merge now follows the displayed file order

## Result
Users can see selected files and reorder them before merging.

Closes #26
<img width="1858" height="939" alt="Screenshot 2026-02-06 203304" src="https://github.com/user-attachments/assets/6215edff-86dd-4c20-8f4d-4817736f1cfd" />
