### PR TITLE
Allow user to remove selected files in merge

### DIFF
--- a/app/dashboard/pdf-merge/page.tsx
+++ b/app/dashboard/pdf-merge/page.tsx
@@ -9,6 +9,10 @@ export default function PdfMergePage() {
   const [isDragging, setIsDragging] = useState(false);
   const [dragIndex, setDragIndex] = useState<number | null>(null);
 
+const removeFile = (indexToRemove: number) => {
+  setFiles((prev) => prev.filter((_, index) => index !== indexToRemove));
+};
+  
 const moveFile = (from: number, to: number) => {
   const updated = [...files];
   const [moved] = updated.splice(from, 1);
@@ -129,11 +133,29 @@ const blob = new Blob([new Uint8Array(mergedBytes)], {
       borderRadius: "5px",
       backgroundColor: "#f0f0f0",
       cursor: "grab",
+      display: "flex",
+      justifyContent: "space-between",
+      alignItems: "center",
     }}
   >
-    📄 {file.name}
+    <span>📄 {file.name}</span>
+
+    <button
+      onClick={() => removeFile(index)}
+      style={{
+        backgroundColor: "#ef4444",
+        color: "white",
+        border: "none",
+        borderRadius: "4px",
+        padding: "4px 8px",
+        cursor: "pointer",
+      }}
+    >
+      Remove
+    </button>
   </div>
 ))}
+
 
 
       <button


### PR DESCRIPTION
### Problem
Users could add files for merging but had no option to remove individual files without refreshing the page.

### Solution
Added a remove button for each selected file.

### Changes made
- Added removeFile function to update state
- Added Remove button in file list UI
- Maintained drag-and-drop reorder functionality
- Ensured smooth state update

### Result
Users can now remove individual files before merging.
<img width="1864" height="943" alt="Screenshot 2026-02-06 230915" src="https://github.com/user-attachments/assets/8114bc6e-93e8-4d15-bae0-9d262f7025a7" />
