### PR TITLE
fix issue-34: Add pdf tools with merge pdf navigation

### DIFF
--- a/app/tool/[id]/page.tsx
+++ b/app/tool/[id]/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ToolCard } from "@/components/ToolCard";
+import { FileText } from "lucide-react";
 import { Upload } from "lucide-react";
 import { useRouter, useParams } from "next/navigation";
 import { useState } from "react";
@@ -9,6 +11,35 @@ export default function ToolUploadPage() {
     const router = useRouter();
     const params = useParams();
     const toolId = params.id;
+    if (toolId === "pdf-tools") {
+    return (
+        <div className="min-h-screen flex flex-col">
+            <main className="flex-1 container mx-auto px-6 py-12 md:px-12">
+
+                <div className="mb-12">
+                    <h1 className="text-3xl font-semibold text-[#1e1e2e] tracking-tight mb-2">
+                        PDF Tools
+                    </h1>
+                    <p className="text-muted-foreground text-lg">
+                        Choose a PDF tool
+                    </p>
+                </div>
+
+                <div className="grid gap-6 md:grid-cols-2 max-w-5xl">
+                    <ToolCard
+                        icon={FileText}
+                        title="Merge PDF"
+                        description="Combine multiple PDFs into one"
+                        href="/dashboard/pdf-merge"
+                        disabled={false}
+                    />
+                </div>
+
+            </main>
+        </div>
+    );
+}
+
 
     const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0];


### PR DESCRIPTION
## Summary
This PR fixes Issue #34 by implementing the PDF Tools page and adding navigation to the Merge PDF tool.

## Problem
The "PDF Tools" card on the dashboard redirected to /tool/pdf-tools, but this page only showed a generic upload UI and did not provide access to the Merge PDF tool.

## Solution
- Added conditional rendering for toolId === "pdf-tools" in app/tool/[id]/page.tsx
- Implemented a ToolCard for "Merge PDF"
- Linked Merge PDF to /dashboard/pdf-merge
- Preserved dynamic routing structure for future PDF tools (Split, Compress, etc.)

## Result
Users can now navigate:

Dashboard → PDF Tools → Merge PDF

## Issue
Fixes #34
<img width="1830" height="932" alt="Screenshot 2026-02-07 124831" src="https://github.com/user-attachments/assets/28188a76-50a8-4ad8-a62f-038cdcb0f44a" />
