### PR TITLE
Fix: add Document to PDF under PDF Tools in dashboard

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -13,6 +13,8 @@ export default function Dashboard() {
 
         {/* Tools Grid matching Image 2 Style */}
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-2 max-w-5xl">
+         
+
           <ToolCard
             icon={FileText}
             title="PDF Tools"

--- a/app/tool/[id]/page.tsx
+++ b/app/tool/[id]/page.tsx
@@ -48,6 +48,16 @@ export default function ToolUploadPage() {
                             disabled={false}
                         />
 
+                        {/* Document to PDF */}
+                        <ToolCard
+                            icon={FileText}
+                            title="Document to PDF"
+                            description="Convert documents into PDF format"
+                            href="/dashboard/document-to-pdf"
+                            disabled={false}
+                        />
+
+
                     </div>
 
                 </main>


### PR DESCRIPTION
Fixes #47

Added a visible "Document to PDF" card under the PDF Tools section
so users can access the feature directly from the Dashboard UI.
