### PR TITLE
Use tool-specific upload titles instead of generic heading

### DIFF
--- a/app/tool/[id]/page.tsx
+++ b/app/tool/[id]/page.tsx
@@ -11,6 +11,22 @@ export default function ToolUploadPage() {
     const router = useRouter();
     const params = useParams();
     const toolId = params.id;
+    const getToolTitle = () => {
+        switch (toolId) {
+            case "file-conversion":
+                return "Upload document to convert";
+            case "ocr":
+                return "Upload image for text extraction";
+            case "data-tools":
+                return "Upload data file to process";
+            default:
+                return "Upload your file";
+        }
+    };
+
+
+
+
 
     // PDF Tools page
     if (toolId === "pdf-tools") {
@@ -72,8 +88,9 @@ export default function ToolUploadPage() {
 
                 <div className="mb-12">
                     <h1 className="text-3xl font-semibold text-[#1e1e2e] tracking-tight mb-2">
-                        Upload your file
+                        {getToolTitle()}
                     </h1>
+
                 </div>
 
                 <div className="w-full max-w-5xl">


### PR DESCRIPTION
- Updated upload page heading dynamically based on tool
- Improves clarity for File Conversion, OCR, and Data Tools
