### PR TITLE
fix:add muliti-page navigation support to pdf redactor

### DIFF
--- a/app/dashboard/pdf-redact/page.tsx
+++ b/app/dashboard/pdf-redact/page.tsx
@@ -35,6 +35,9 @@ export default function PdfRedactPage() {
   const [isDraggingOver, setIsDraggingOver] = useState(false);
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
+const [pdfDoc, setPdfDoc] = useState<any>(null);
+const [pageNumber, setPageNumber] = useState(1);
+const [totalPages, setTotalPages] = useState(0);
 
   // Load PDF
   const loadPDF = async (selectedFile: File) => {
@@ -44,10 +47,15 @@ export default function PdfRedactPage() {
     const arrayBuffer = await selectedFile.arrayBuffer();
 
     const pdf = await pdfjsLib.getDocument({
-      data: arrayBuffer,
-    }).promise;
+  data: arrayBuffer,
+}).promise;
 
-    await renderPage(pdf, 1);
+setPdfDoc(pdf);
+setTotalPages(pdf.numPages);
+setPageNumber(1);
+
+await renderPage(pdf, 1);
+
   };
 
   // File input change
@@ -99,6 +107,23 @@ export default function PdfRedactPage() {
       viewport,
     }).promise;
   };
+
+  const goToNextPage = async () => {
+  if (!pdfDoc || pageNumber >= totalPages) return;
+
+  const nextPage = pageNumber + 1;
+  setPageNumber(nextPage);
+  await renderPage(pdfDoc, nextPage);
+};
+
+const goToPrevPage = async () => {
+  if (!pdfDoc || pageNumber <= 1) return;
+
+  const prevPage = pageNumber - 1;
+  setPageNumber(prevPage);
+  await renderPage(pdfDoc, prevPage);
+};
+
 
   // Drawing logic
   const handleMouseDown = (e: React.MouseEvent<HTMLCanvasElement>) => {
@@ -254,6 +279,27 @@ export default function PdfRedactPage() {
           {file.name}
         </div>
       )}
+<div className="flex justify-between items-center mt-4">
+  <button
+    onClick={goToPrevPage}
+    disabled={pageNumber <= 1}
+    className="px-4 py-2 bg-gray-200 rounded disabled:opacity-50"
+  >
+    Previous
+  </button>
+
+  <span>
+    Page {pageNumber} of {totalPages}
+  </span>
+
+  <button
+    onClick={goToNextPage}
+    disabled={pageNumber >= totalPages}
+    className="px-4 py-2 bg-gray-200 rounded disabled:opacity-50"
+  >
+    Next
+  </button>
+</div>
 
       {/* Canvas */}
       {file && (


### PR DESCRIPTION
Fixes #72

## Problem
PDF Redactor only displayed the first page of multi-page PDFs, making it impossible to redact other pages.

## Solution
- Added PDF state management
- Added page navigation (Next / Previous)
- Added page number indicator
- Enabled rendering of all pages

## Result
Users can now navigate and redact all pages of multi-page PDFs.
<img width="1843" height="813" alt="Screenshot 2026-02-09 110432" src="https://github.com/user-attachments/assets/e8361070-3a91-4961-8aa2-89cc2b8a3038" />
