### PR TITLE
add erase to pdf redact also(fixed import placement causing parsing error)

### DIFF
--- a/app/tool/[id]/page.tsx
+++ b/app/tool/[id]/page.tsx
@@ -1,64 +1,165 @@
 "use client";
 
-import { ArrowLeft, FileText, Upload } from "lucide-react";
+import {
+  ArrowLeft,
+  FileText,
+  Upload,
+  Combine,
+  Scissors,
+  FileUp,
+} from "lucide-react";
+
 import { ToolCard } from "@/components/ToolCard";
-import { Combine, Scissors, FileUp, Upload } from "lucide-react";
 import { useRouter, useParams } from "next/navigation";
 import { motion } from "framer-motion";
+import { useEffect, useRef, useState } from "react";
 
 export default function ToolUploadPage() {
   const router = useRouter();
   const params = useParams();
+  const toolId = params.id as string;
 
-  // Ensure toolId is always string
-  const toolId = Array.isArray(params.id) ? params.id[0] : params.id;
+  const [hasUnsavedWork, setHasUnsavedWork] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [fileError, setFileError] = useState<string | null>(null);
+  const [isDraggingOver, setIsDraggingOver] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
-  // =========================
-  // PDF TOOLS PAGE
-  // =========================
+  // Warn before refresh
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (!hasUnsavedWork) return;
+      e.preventDefault();
+      e.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    return () =>
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [hasUnsavedWork]);
+
+  const getToolTitle = () => {
+    switch (toolId) {
+      case "document-to-pdf":
+        return "Upload document to convert";
+      case "ocr":
+        return "Upload image for text extraction";
+      default:
+        return "Upload your file";
+    }
+  };
+
+  const getSupportedTypes = () => {
+    switch (toolId) {
+      case "document-to-pdf":
+        return [".doc", ".docx", ".ppt", ".pptx", ".xls", ".xlsx"];
+      case "ocr":
+        return [".jpg", ".jpeg", ".png"];
+      case "pdf-tools":
+      case "pdf-merge":
+      case "pdf-split":
+      case "pdf-protect":
+      case "pdf-redact":
+        return [".pdf"];
+      default:
+        return [];
+    }
+  };
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const allowedTypes = getSupportedTypes();
+    const extension =
+      "." + file.name.split(".").pop()?.toLowerCase();
+
+    if (allowedTypes.length && !allowedTypes.includes(extension)) {
+      setFileError(
+        `Unsupported file type. Allowed: ${allowedTypes.join(", ")}`
+      );
+      return;
+    }
+
+    setFileError(null);
+    setSelectedFile(file);
+    setHasUnsavedWork(true);
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDraggingOver(true);
+  };
+
+  const handleDragLeave = () => {
+    setIsDraggingOver(false);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDraggingOver(false);
+
+    const file = e.dataTransfer.files?.[0];
+    if (!file) return;
+
+    setSelectedFile(file);
+    setHasUnsavedWork(true);
+  };
+
+  const handleBackNavigation = () => {
+    if (hasUnsavedWork) {
+      const confirmLeave = window.confirm(
+        "You have unsaved work. Leave?"
+      );
+      if (!confirmLeave) return;
+    }
+
+    router.push("/dashboard");
+  };
+
+  // PDF tools page
   if (toolId === "pdf-tools") {
     return (
       <div className="min-h-screen flex flex-col">
-        <main className="flex-1 container mx-auto px-6 py-12 md:px-12">
 
-          <div className="mb-12">
-            <h1 className="text-3xl font-semibold text-[#1e1e2e] tracking-tight mb-2">
-              PDF Tools
-            </h1>
+        <div className="container mx-auto px-6 pt-6">
+          <button
+            onClick={handleBackNavigation}
+            className="flex items-center gap-2 text-sm"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back
+          </button>
+        </div>
 
-            <p className="text-muted-foreground text-lg">
-              Choose a PDF tool
-            </p>
-          </div>
+        <main className="container mx-auto px-6 py-12">
 
-          {/* Tools Grid */}
+          <h1 className="text-3xl font-semibold mb-6">
+            PDF Tools
+          </h1>
+
           <div className="grid gap-6 md:grid-cols-2 max-w-5xl">
 
-            {/* Merge PDF */}
             <ToolCard
               icon={Combine}
               title="Merge PDF"
-              description="Combine multiple PDFs into one"
+              description="Combine PDFs"
               href="/dashboard/pdf-merge"
-              disabled={false}
             />
 
-            {/* Split PDF */}
             <ToolCard
               icon={Scissors}
               title="Split PDF"
-              description="Split PDF into separate pages"
+              description="Split PDF"
               href="/dashboard/pdf-split"
-              disabled={false}
             />
 
-            {/* Document to PDF */}
             <ToolCard
               icon={FileUp}
               title="Document to PDF"
-              description="Convert documents into PDF format"
+              description="Convert document"
               href="/dashboard/document-to-pdf"
-              disabled={false}
             />
 
           </div>
@@ -68,338 +169,69 @@ export default function ToolUploadPage() {
     );
   }
 
-  // =========================
-  // FILE UPLOAD PAGE
-  // =========================
-  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-
-    if (file) {
-      setTimeout(() => {
-        router.push(`/tool/${toolId}/processing`);
-      }, 500);
-    }
-  };
-
+  // Upload page
   return (
     <div className="min-h-screen flex flex-col">
-      <main className="flex-1 container mx-auto px-6 py-12 md:px-12">
 
-        <div className="mb-12">
-          <h1 className="text-3xl font-semibold text-[#1e1e2e] tracking-tight mb-2">
-            Upload your file
-          </h1>
-        </div>
+      <main className="container mx-auto px-6 py-12">
 
-        <div className="w-full max-w-5xl">
-          <motion.div
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="relative w-full rounded-2xl border-2 border-dashed border-[#ccdcdb] bg-[#eef6f5] hover:bg-[#e4eff0] transition-colors"
-          >
-            <label className="flex flex-col items-center justify-center w-full h-[400px] cursor-pointer">
+        <button
+          onClick={handleBackNavigation}
+          className="flex items-center gap-2 mb-6"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back
+        </button>
 
-              <div className="flex flex-col items-center justify-center pt-5 pb-6">
+        <h1 className="text-3xl font-semibold mb-8">
+          {getToolTitle()}
+        </h1>
 
-                <div className="mb-6 text-[#1e1e2e]">
-                  <Upload className="w-16 h-16 stroke-1" />
-                </div>
+        <motion.div
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+          className="border-2 border-dashed rounded-xl p-20 text-center"
+        >
 
-                <p className="mb-2 text-xl text-[#1e1e2e] font-medium">
-                  Drag & drop your file here
-                </p>
+          <Upload className="mx-auto mb-4" />
 
-                <p className="text-base text-muted-foreground">
-                  or click to browse
-                </p>
+          <p>Drag & drop or click</p>
 
-              </div>
+          <input
+            type="file"
+            ref={fileInputRef}
+            className="hidden"
+            onChange={handleFile}
+          />
 
-              <input
-                type="file"
-                className="hidden"
-                onChange={handleFile}
-              />
+        </motion.div>
 
-            </label>
-          </motion.div>
+        {selectedFile && (
+          <div className="mt-4">
 
-          <div className="flex justify-between text-xs text-muted-foreground mt-4 px-1">
-            <span>Supported formats: PDF, JPG, PNG</span>
-            <span>Max file size: 10MB</span>
+            <p>{selectedFile.name}</p>
+
+            <button
+              onClick={() =>
+                router.push(`/tool/${toolId}/processing`)
+              }
+              className="mt-2 px-4 py-2 bg-black text-white rounded"
+            >
+              Process File
+            </button>
+
           </div>
+        )}
 
-        </div>
+        {fileError && (
+          <p className="text-red-500 mt-2">
+            {fileError}
+          </p>
+        )}
 
       </main>
+
     </div>
   );
-import { useParams, useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
-import { motion } from "framer-motion";
-
-export default function ToolUploadPage() {
-    const router = useRouter();
-    const params = useParams();
-    const toolId = params.id as string;
-
-    const [hasUnsavedWork, setHasUnsavedWork] = useState(false);
-    const [selectedFile, setSelectedFile] = useState<File | null>(null);
-    const [fileError, setFileError] = useState<string | null>(null);
-    const [isDraggingOver, setIsDraggingOver] = useState(false);
-    const fileInputRef = useRef<HTMLInputElement | null>(null);
-
-    // Warn on refresh / tab close
-    useEffect(() => {
-        const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-            if (!hasUnsavedWork) return;
-            e.preventDefault();
-            e.returnValue = "";
-        };
-
-        window.addEventListener("beforeunload", handleBeforeUnload);
-        return () => {
-            window.removeEventListener("beforeunload", handleBeforeUnload);
-        };
-    }, [hasUnsavedWork]);
-
-    const getToolTitle = () => {
-        switch (toolId) {
-            case "file-conversion":
-                return "Upload document to convert";
-            case "ocr":
-                return "Upload image for text extraction";
-            case "data-tools":
-                return "Upload data file to process";
-            default:
-                return "Upload your file";
-        }
-    };
-
-    const getSupportedTypes = () => {
-        switch (toolId) {
-            case "document-to-pdf":
-                return [".doc", ".docx", ".ppt", ".pptx", ".xls", ".xlsx"];
-            case "ocr":
-                return [".jpg", ".jpeg", ".png"];
-            case "pdf-tools":
-            case "pdf-merge":
-            case "pdf-split":
-            case "pdf-protect":
-            case "pdf-redact":
-                return [".pdf"];
-            default:
-                return [];
-        }
-    };
-
-    const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const file = e.target.files?.[0];
-        if (!file) return;
-
-        const allowedTypes = getSupportedTypes();
-        const fileExtension = "." + file.name.split(".").pop()?.toLowerCase();
-
-        if (allowedTypes.length && !allowedTypes.includes(fileExtension)) {
-            setFileError(
-                `Unsupported file type. Please upload ${allowedTypes.join(", ")} file(s).`
-            );
-            e.target.value = "";
-            return;
-        }
-
-        setFileError(null);
-        setSelectedFile(file);
-        setHasUnsavedWork(true);
-    };
-
-    const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
-        e.preventDefault();
-        if (!isDraggingOver) {
-            setIsDraggingOver(true);
-        }
-    };
-
-    const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
-        const relatedTarget = e.relatedTarget as Node | null;
-        if (relatedTarget && e.currentTarget.contains(relatedTarget)){
-            return;
-        }
-    };
-
-    const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
-        e.preventDefault();
-        setIsDraggingOver(false);
-
-        const file = e.dataTransfer.files?.[0];
-        if (!file) return;
-
-        const allowedTypes = getSupportedTypes();
-        const fileExtension = "." + file.name.split(".").pop()?.toLowerCase();
-
-        if (allowedTypes.length && !allowedTypes.includes(fileExtension)) {
-            setFileError(
-                `Unsupported file type. Please upload ${allowedTypes.join(", ")} file(s).`
-            );
-            return;
-        }
-
-        setFileError(null);
-        setSelectedFile(file);
-        setHasUnsavedWork(true);
-    };
-
-    const handleBackNavigation = () => {
-        if (hasUnsavedWork) {
-            const confirmLeave = window.confirm(
-                "You have unsaved work. Are you sure you want to leave this page?"
-            );
-            if (!confirmLeave) return;
-        }
-        router.push("/dashboard");
-    };
-
-    // PDF Tools page
-    if (toolId === "pdf-tools") {
-        return (
-            <div className="min-h-screen flex flex-col">
-                <div className="container mx-auto px-6 pt-6 md:px-12">
-                    <button
-                        onClick={handleBackNavigation}
-                        className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-[#1e1e2e]"
-                    >
-                        <ArrowLeft className="w-4 h-4" />
-                        Back to Dashboard
-                    </button>
-                </div>
-
-                <main className="flex-1 container mx-auto px-6 py-12 md:px-12">
-                    <div className="mb-12">
-                        <h1 className="text-3xl font-semibold text-[#1e1e2e] tracking-tight mb-2">
-                            PDF Tools
-                        </h1>
-                        <p className="text-muted-foreground text-lg">
-                            Choose a PDF tool
-                        </p>
-                    </div>
-
-                    <div className="grid gap-6 md:grid-cols-2 max-w-5xl">
-                        <ToolCard icon={FileText} title="Merge PDF" description="Combine multiple PDFs into one" href="/dashboard/pdf-merge" />
-                        <ToolCard icon={FileText} title="Split PDF" description="Split PDF into separate pages" href="/dashboard/pdf-split" />
-                        <ToolCard icon={FileText} title="Document to PDF" description="Convert documents into PDF format" href="/dashboard/document-to-pdf" />
-                        <ToolCard icon={FileText} title="Protect PDF" description="Secure your PDF with a password" href="/dashboard/pdf-protect" />
-                        <ToolCard icon={FileText} title="Redact PDF" description="Remove sensitive information from your PDF" href="/dashboard/pdf-redact" />
-                    </div>
-                </main>
-            </div>
-        );
-    }
-
-    // Upload page
-    return (
-        <div className="min-h-screen flex flex-col">
-            <main className="flex-1 container mx-auto px-6 py-12 md:px-12">
-                <button
-                    onClick={handleBackNavigation}
-                    className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-[#1e1e2e] mb-6"
-                >
-                    <ArrowLeft className="w-4 h-4" />
-                    Back to Dashboard
-                </button>
-
-                <h1 className="text-3xl font-semibold text-[#1e1e2e] mb-12">
-                    {getToolTitle()}
-                </h1>
-
-                <div className="w-full max-w-5xl">
-                    <motion.div
-                        initial={{ opacity: 0, y: 10 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        onDragOver={handleDragOver}
-                        onDragLeave={handleDragLeave}
-                        onDrop={handleDrop}
-                        className={`relative w-full rounded-2xl border-2 border-dashed transition-colors ${
-                            isDraggingOver
-                                ? "border-[#1e1e2e] bg-[#d9ebea]"
-                                : "border-[#ccdcdb] bg-[#eef6f5] hover:bg-[#e4eff0]"
-                        }`}
-                    >
-                        <label className="flex flex-col items-center justify-center h-[400px] cursor-pointer">
-                            <Upload className="w-16 h-16 mb-4" />
-                            <p className="text-xl font-medium">
-                                {isDraggingOver ? "Drop your file here" : "Drag & drop your file here"}
-                            </p>
-                            <p className="text-muted-foreground">
-                                or click to browse
-                            </p>
-                            <input
-                                type="file"
-                                className="hidden"
-                                ref={fileInputRef}
-                                onChange={handleFile}
-                            />
-                        </label>
-                        
-                    </motion.div>
-                    <div className="flex items-center gap-6 mt-6">
-                                <button
-                                    onClick={() => {
-                                        setSelectedFile(null);
-                                        setHasUnsavedWork(false);
-                                    }}
-                                    className="text-xs text-red-500 hover:underline"
-                                >
-                                    Remove
-                                </button>
-                                <button
-                                    onClick={() => {
-                                        router.push(`/tool/${toolId}/processing`);
-                                    }}
-                                    className="px-4 py-2 bg-[#1e1e2e] text-white text-sm font-medium rounded-lg hover:bg-[#2e2e3e] transition-colors"
-                                >
-                                    Process File
-                                </button>
-                            </div>
-                    {fileError && (
-                        <p className="mt-3 text-sm text-red-600">
-                            {fileError}
-                        </p>
-                    )}
-
-                    {selectedFile && (
-                        <div className="mt-4 flex items-center justify-between rounded-lg border bg-white px-4 py-3 text-sm">
-                            <div>
-                                <p className="font-medium text-[#1e1e2e]">
-                                    {selectedFile.name}
-                                </p>
-                                <p className="text-xs text-muted-foreground">
-                                    {(selectedFile.size / 1024 / 1024).toFixed(2)} MB
-                                </p>
-                            </div>
-
-                            <button
-                                onClick={() => {
-                                    setSelectedFile(null);
-                                    setHasUnsavedWork(false);
-                                }}
-                                className="text-xs text-red-500 hover:underline"
-                            >
-                                Remove
-                            </button>
-                        </div>
-                    )}
-
-                    <div className="flex justify-between text-xs text-muted-foreground mt-4 px-1">
-                        <span>
-                            Supported formats:{" "}
-                            {getSupportedTypes().length > 0
-                                ? getSupportedTypes().join(", ")
-                                : "See tool requirements"}
-                        </span>
-                        <span>Max file size: 10MB</span>
-                    </div>
-                </div>
-            </main>
-        </div>
-    );
 }


### PR DESCRIPTION


This PR introduces an **Eraser Tool** to the PDF Redactor, allowing users to remove previously drawn redaction rectangles without needing to reload the PDF and start over.

This significantly improves usability, especially when working with precise or multiple redactions.

---

### Changes Made

#### 1. Added Tool State Management

* Introduced a new `tool` state (`"redact"` | `"erase"`) to allow switching between Redact and Eraser modes.
* Default tool remains **Redact** to preserve existing behavior.

#### 2. Implemented Eraser Functionality

* Users can now click inside an existing redaction rectangle to remove it when Eraser Tool is selected.
* Erase detection includes padding tolerance for easier interaction.
* Ensures only rectangles on the current page are affected.

#### 3. Added Tool Selector UI

* Added buttons to switch between:

  * Redact Tool
  * Eraser Tool
* Active tool is visually highlighted for clarity.

#### 4. Fixed Import Placement Parsing Error

* Corrected import placement to comply with Next.js and TypeScript parsing rules.
* Prevents build/runtime parsing failures.

#### 5. Improved Interaction Reliability

* Added `pointerEvents: "none"` to rectangle overlays so canvas receives mouse events properly.
* Ensures erase clicks are correctly detected.

---

### Why This Change is Needed

Previously, users could not undo or adjust redactions without reloading the entire PDF. This was inefficient and negatively impacted workflow.

This PR enables precise correction and improves the overall user experience.

---

### Result

Users can now:

* Add redactions
* Remove specific redactions
* Work more efficiently without restarting

---
### Issue

Fixes #89


<img width="1367" height="855" alt="Screenshot 2026-02-09 184356" src="https://github.com/user-attachments/assets/a64ac7e6-cb05-4f36-a231-6a42c040f74f" />
