### PR TITLE
fix: resolve module not found error by adding HelpTooltip component

### DIFF
--- a/components/HelpTooltip.tsx
+++ b/components/HelpTooltip.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Info } from "lucide-react";
+
+interface HelpTooltipProps {
+  text: string;
+}
+
+export function HelpTooltip({ text }: HelpTooltipProps) {
+  return (
+    <div className="relative group inline-block">
+      <Info className="w-4 h-4 text-gray-400 cursor-pointer" />
+
+      <div className="absolute bottom-full mb-2 hidden group-hover:block
+        bg-black text-white text-xs rounded px-2 py-1 whitespace-nowrap z-50">
+        {text}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Fixes a build error caused by a missing HelpTooltip component.

The tool page (`app/tool/[id]/page.tsx`) imports `HelpTooltip` from `@/components/HelpTooltip`, but the component file did not exist in the repository, causing the following error:

Module not found: Can't resolve '@/components/HelpTooltip'

## Changes Made

- Added new component: `components/HelpTooltip.tsx`
- Implemented a simple reusable tooltip using lucide-react Info icon
- Ensured compatibility with existing UI and Next.js client components

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impact

- Fixes build failure
- Restores proper functionality of tool page
- Improves UI with helpful tooltip support

## Testing

- Verified project builds successfully
- Verified tooltip renders correctly on tool page