### PR TITLE
Add Metadata Viewer tool to extract and display file metadata

### DIFF
--- a/app/dashboard/metadata-viewer/page.tsx
+++ b/app/dashboard/metadata-viewer/page.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useState } from 'react';
+import { FileUp, FileText } from 'lucide-react';
+
+export default function MetadataViewerPage() {
+  const [file, setFile] = useState<File | null>(null);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      setFile(e.target.files[0]);
+    }
+  };
+
+  const formatSize = (size: number) => {
+    if (size < 1024) return size + ' bytes';
+    if (size < 1024 * 1024) return (size / 1024).toFixed(2) + ' KB';
+    return (size / (1024 * 1024)).toFixed(2) + ' MB';
+  };
+
+  return (
+    <div className="min-h-screen p-6 bg-gray-50 dark:bg-gray-900">
+      <div className="max-w-xl mx-auto bg-white dark:bg-gray-800 shadow-lg rounded-2xl p-6">
+
+        <h1 className="text-2xl font-bold mb-4 flex items-center gap-2">
+          <FileText className="w-6 h-6" />
+          Metadata Viewer
+        </h1>
+
+        <label className="flex flex-col items-center justify-center border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-xl p-6 cursor-pointer hover:border-blue-500 transition">
+
+          <FileUp className="w-8 h-8 mb-2" />
+
+          <span className="text-gray-600 dark:text-gray-300">
+            Click to upload a file
+          </span>
+
+          <input
+            type="file"
+            className="hidden"
+            onChange={handleFileChange}
+          />
+        </label>
+
+        {file && (
+          <div className="mt-6 space-y-2">
+
+            <div>
+              <strong>Name:</strong> {file.name}
+            </div>
+
+            <div>
+              <strong>Type:</strong> {file.type || 'Unknown'}
+            </div>
+
+            <div>
+              <strong>Size:</strong> {formatSize(file.size)}
+            </div>
+
+            <div>
+              <strong>Last Modified:</strong>{' '}
+              {new Date(file.lastModified).toLocaleString()}
+            </div>
+
+          </div>
+        )}
+
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
This PR adds a new Metadata Viewer tool that allows users to upload files and view important metadata.

## Features added
- Upload any file
- Display file name
- Display file type
- Display file size
- Display last modified date

## Why this is needed
This improves the usability of DocuHub by allowing users to inspect file metadata without external tools.

Fixes #139
<img width="726" height="450" alt="Screenshot 2026-02-11 164819" src="https://github.com/user-attachments/assets/0124d010-6398-4bac-a9b3-53fbe8a43f9e" />
