### PR TITLE
Display file size comparison after PDF compression

### DIFF
--- a/app/tool/[id]/processing/page.tsx
+++ b/app/tool/[id]/processing/page.tsx
@@ -231,6 +231,27 @@ const [compressedSize, setCompressedSize] = useState<number | null>(null);
           </button>
         )}
 
+        {toolId === "pdf-compress" &&
+  originalSize &&
+  compressedSize && (
+    <div className="mt-6 p-4 bg-gray-100 rounded-lg text-sm">
+      <p>
+        Original Size: {(originalSize / (1024 * 1024)).toFixed(2)} MB
+      </p>
+      <p>
+        Compressed Size: {(compressedSize / (1024 * 1024)).toFixed(2)} MB
+      </p>
+      <p className="font-semibold text-green-600">
+        Reduced by {(
+          ((originalSize - compressedSize) / originalSize) *
+          100
+        ).toFixed(1)}
+        %
+      </p>
+    </div>
+  )}
+
+
         {toolId === "ocr" && (
           <button
             onClick={copyText}


### PR DESCRIPTION
## Problem

Currently, after PDF compression, users can download the file
but do not see how much size reduction was achieved.

## Proposed Solution

After compression:
- Display original file size
- Display compressed file size
- Show percentage reduction

## Benefits

- Better transparency
- Improved user experience
- Provides measurable compression results
