### PR TITLE
fix: remove duplicate pdf-rotate entry causing React key error

### DIFF
--- a/lib/pdfTools.ts
+++ b/lib/pdfTools.ts
@@ -60,15 +60,6 @@ export const PDF_TOOLS = Object.freeze([
     icon: Scissors,
   },
 
-  // ✅ NEW ROTATE TOOL
-  {
-    id: "pdf-rotate",
-    title: "Rotate PDF",
-    description: "Rotate PDF pages",
-    href: "/tool/pdf-rotate",
-    icon: FileText,
-  },
-
   {
     id: "pdf-protect",
     title: "Protect PDF",


### PR DESCRIPTION
## Description

This PR fixes a React rendering error that occurred when loading the  page. The error was:

```
Encountered two children with the same key, `pdf-rotate`. Keys should be unique so that components maintain their identity across updates.
```

## Root Cause

The `PDF_TOOLS` array in `lib/pdfTools.ts` contained two entries with the same `id: pdf-rotate`:

1. First entry (now removed): Had `icon: FileText`
2. Second entry (kept): Has `icon: RotateCw` - more appropriate for a rotate tool

## Changes

- Removed the duplicate `pdf-rotate` entry from the `PDF_TOOLS` array
- All tool IDs are now unique, fixing the React key error

## Testing

The fix can be verified by visiting any page that renders the PDF tools grid (e.g., `/tool/pdf-tools` or the dashboard) - the console error should no longer appear.