### PR TITLE
Remove false-success fallback for unsupported tool routes

### DIFF
--- a/app/tool/[id]/page.tsx
+++ b/app/tool/[id]/page.tsx
@@ -21,6 +21,23 @@ import {
 } from "@/lib/toolStateStorage";
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
+const UPLOAD_ENABLED_TOOLS = new Set([
+  "ocr",
+  "jpeg-to-pdf",
+  "png-to-pdf",
+  "pdf-protect",
+  "pdf-compress",
+  "pdf-watermark",
+  "pdf-page-numbers",
+]);
+const CATEGORY_TOOLS = new Set(["pdf-tools"]);
+const MOVED_TO_DASHBOARD: Record<string, string> = {
+  "pdf-merge": "/dashboard/pdf-merge",
+  "document-to-pdf": "/dashboard/document-to-pdf",
+  "pdf-split": "/dashboard/pdf-split",
+  "pdf-redact": "/dashboard/pdf-redact",
+  "metadata-viewer": "/dashboard/metadata-viewer",
+};
 
 export default function ToolUploadPage() {
   const router = useRouter();
@@ -101,13 +118,10 @@ export default function ToolUploadPage() {
         return [".jpg", ".jpeg"];
       case "png-to-pdf":
         return [".png"];
-      case "pdf-merge":
-      case "pdf-split":
       case "pdf-protect":
       case "pdf-compress":
       case "pdf-watermark":
       case "pdf-page-numbers":
-      case "pdf-rotate":
         return [".pdf"];
       default:
         return [];
@@ -220,7 +234,7 @@ export default function ToolUploadPage() {
   };
 
   /* Tools page */
-  if (toolId === "pdf-tools") {
+  if (CATEGORY_TOOLS.has(toolId)) {
     return (
       <div className="min-h-screen flex flex-col">
         <main className="container mx-auto px-6 py-12 md:px-12">
@@ -233,6 +247,43 @@ export default function ToolUploadPage() {
             ))}
           </div>
         </main>
+      </div>
+    );
+  }
+
+  const dashboardFallback = MOVED_TO_DASHBOARD[toolId];
+  if (!UPLOAD_ENABLED_TOOLS.has(toolId)) {
+    const heading = dashboardFallback
+      ? "This tool moved to Dashboard"
+      : "This tool is currently unavailable";
+    const details = dashboardFallback
+      ? "Use the dashboard route for this tool."
+      : "Choose an available tool to continue.";
+
+    return (
+      <div className="min-h-screen flex items-center justify-center px-6">
+        <div className="max-w-md w-full text-center border rounded-xl p-6">
+          <h1 className="text-2xl font-semibold">{heading}</h1>
+          <p className="text-muted-foreground mt-2">
+            {details} (Tool ID: {toolId})
+          </p>
+          <div className="mt-6 flex flex-col gap-3">
+            {dashboardFallback && (
+              <button
+                onClick={() => router.push(dashboardFallback)}
+                className="w-full py-3 rounded-lg text-sm font-medium bg-black text-white hover:bg-gray-800"
+              >
+                Open Tool
+              </button>
+            )}
+            <button
+              onClick={() => router.push("/dashboard")}
+              className="w-full py-3 rounded-lg text-sm font-medium border border-gray-300 hover:bg-gray-50"
+            >
+              Back to Dashboard
+            </button>
+          </div>
+        </div>
       </div>
     );
   }

--- a/app/tool/[id]/processing/page.tsx
+++ b/app/tool/[id]/processing/page.tsx
@@ -13,6 +13,16 @@ type StoredFile = {
   type: string;
 };
 
+const SUPPORTED_PROCESSING_TOOLS = new Set([
+  "ocr",
+  "pdf-protect",
+  "jpeg-to-pdf",
+  "png-to-pdf",
+  "pdf-watermark",
+  "pdf-compress",
+  "pdf-page-numbers",
+]);
+
 export default function ProcessingPage() {
   const router = useRouter();
   const params = useParams();
@@ -33,6 +43,14 @@ export default function ProcessingPage() {
   useEffect(() => {
     const run = async () => {
       const stored = getStoredFiles() as StoredFile[];
+
+      if (!SUPPORTED_PROCESSING_TOOLS.has(toolId)) {
+        setError(
+          `Unsupported tool "${toolId}". Please choose an available tool from the dashboard.`
+        );
+        setStatus("error");
+        return;
+      }
 
       if (!stored?.length) {
         router.push(`/tool/${toolId}`);
@@ -59,8 +77,6 @@ export default function ProcessingPage() {
         else if (toolId === "pdf-page-numbers") {
           await addPageNumbers(stored[0].data);
         }
-
-        else setStatus("done");
 
       } catch (e) {
         console.error(e);
@@ -315,7 +331,13 @@ export default function ProcessingPage() {
       <div className="min-h-screen flex items-center justify-center text-center">
         <div>
           <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-3"/>
-          <p>{error}</p>
+          <p>{error || "Processing failed."}</p>
+          <button
+            onClick={() => router.push("/dashboard")}
+            className="mt-4 px-4 py-2 rounded-lg border border-gray-300 hover:bg-gray-50"
+          >
+            Return to Dashboard
+          </button>
         </div>
       </div>
     );


### PR DESCRIPTION
Summary                                                                                                                                                       
  This PR fixes a routing/processing gap where unknown tool IDs could incorrectly report success (setStatus("done")) without doing any work.                    
                                                                                                                                                                
  Changes                                                                                                                                                       
                                                                                                                                                                
  - Updated DocuHub/app/tool/[id]/processing/page.tsx                                                                                                           
  - Added explicit allowlist of processing-supported tool IDs.                                                                                                  
  - Replaced implicit fallback success with explicit unsupported-tool error.                                                                                    
  - Added recovery action in error UI: Return to Dashboard.                                                                                                     
  - Updated DocuHub/app/tool/[id]/page.tsx                                                                                                                      
  - Added explicit route classification:                                                                                                                        
      - upload-enabled tools                                                                                                                                    
      - category tools                                                                                                                                          
      - moved-to-dashboard tools                                                                                                                                
  - Non-implemented tool IDs now render clear unavailable state.                                                                                                
  - Moved tools now show recovery actions: Open Tool + Back to Dashboard.                                                                                       
  - Removed implicit supported-type signaling for non-implemented tools.                                                                                        
                                                                                                                                                                
  Why                                                                                                                                                           
                                                                                                                                                                
  - Prevents false-positive completion states.                                                                                                                  
  - Makes route behavior deterministic and user-facing for unsupported IDs.                                                                                     
  - Satisfies requirement that routed IDs are implemented or clearly unavailable.                                                                               
                                                                                                                                                                
  Acceptance Criteria                                                                                                                                           
                                                                                                                                                                
  - Unsupported tool IDs show explicit error + recovery action: ✅                                                                                              
  - Every routed tool ID is implemented or marked unavailable: ✅                                                                                               
                                                                                                                                                                
  Manual Test Cases                                                                                                                                             
                                                                                                                                                                
  1. /tool/jpeg-to-pdf processes successfully.                                                                                                                  
  2. /tool/pdf-rotate/processing shows unsupported error + dashboard recovery.                                                                                  
  3. /tool/pdf-rotate shows unavailable state.                                                                                                                  
  4. /tool/metadata-viewer shows moved-to-dashboard state with Open Tool.                                                                                       
  5. /tool/not-a-real-tool shows unavailable state. 
  
  issue closed #322 