### PR TITLE
Fix pdf-rotate state inconsistency and wire rotate processing to canonical UI config 

### DIFF
--- a/app/tool/[id]/page.tsx
+++ b/app/tool/[id]/page.tsx
@@ -29,6 +29,7 @@ const UPLOAD_ENABLED_TOOLS = new Set([
   "pdf-compress",
   "pdf-watermark",
   "pdf-page-numbers",
+  "pdf-rotate",
 ]);
 const CATEGORY_TOOLS = new Set(["pdf-tools"]);
 const MOVED_TO_DASHBOARD: Record<string, string> = {
@@ -59,13 +60,14 @@ export default function ToolUploadPage() {
   const [opacity, setOpacity] = useState(40);
 
   /* Rotate PDF */
-  const [pagesToRotate, setPagesToRotate] = useState("");
+  const [rotateConfig, setRotateConfig] = useState({
+    angle: 90,
+    pages: "",
+  });
 
   /* Page Numbers */
   const [pageNumberFormat, setPageNumberFormat] = useState("numeric");
   const [pageNumberFontSize, setPageNumberFontSize] = useState(14);
-
-  const [rotationAngleOption, setRotationAngleOption] = useState("90");
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -122,6 +124,7 @@ export default function ToolUploadPage() {
       case "pdf-compress":
       case "pdf-watermark":
       case "pdf-page-numbers":
+      case "pdf-rotate":
         return [".pdf"];
       default:
         return [];
@@ -195,9 +198,7 @@ export default function ToolUploadPage() {
       }
 
       if (toolId === "pdf-rotate") {
-        localStorage.setItem("rotationAngle", rotationAngle.toString());
-        localStorage.setItem("pagesToRotate", pagesToRotate);
-        localStorage.setItem("pdfRotateAngle", rotationAngleOption);
+        localStorage.setItem("pdfRotateConfig", JSON.stringify(rotateConfig));
       }
 
       if (toolId === "pdf-watermark") {
@@ -368,6 +369,48 @@ export default function ToolUploadPage() {
                 </button>
               </div>
             ))}
+          </div>
+        )}
+
+        {toolId === "pdf-rotate" && (
+          <div className="mt-6 rounded-xl border bg-white p-4 space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-2">
+                Rotation Angle
+              </label>
+              <select
+                value={rotateConfig.angle}
+                onChange={e =>
+                  setRotateConfig(prev => ({
+                    ...prev,
+                    angle: Number(e.target.value),
+                  }))
+                }
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+              >
+                <option value={90}>90°</option>
+                <option value={180}>180°</option>
+                <option value={270}>270°</option>
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-2">
+                Pages (optional)
+              </label>
+              <input
+                type="text"
+                value={rotateConfig.pages}
+                onChange={e =>
+                  setRotateConfig(prev => ({
+                    ...prev,
+                    pages: e.target.value,
+                  }))
+                }
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+                placeholder="all pages, or e.g. 1,3-5"
+              />
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
This PR fixes pdf-rotate configuration drift by introducing one canonical rotate state and ensuring processing consumes exactly what the upload UI sets.      
                                                                                                                                                                
  What changed                                                                                                                                                  
                                                                                                                                                                
  1. app/tool/[id]/page.tsx                                                                                                                                     
                                                                                                                                                                
  - Added pdf-rotate to upload-enabled tools and PDF-supported file types.                                                                                      
  - Replaced split rotate state usage with a single rotateConfig object:                                                                                        
      - angle: number                                                                                                                                           
      - pages: string                                                                                                                                           
  - Removed legacy rotate persistence keys usage.                                                                                                               
  - Persist rotate settings under one key only: pdfRotateConfig.                                                                                                
  - Added rotate controls in upload UI:                                                                                                                         
      - angle selector (90, 180, 270)                                                                                                                           
      - page selection input (1,3-5 style)                                                                                                                      
                                                                                                                                                                
  2. app/tool/[id]/processing/page.tsx                                                                                                                          
                                                                                                                                                                
  - Added pdf-rotate to SUPPORTED_PROCESSING_TOOLS.                                                                                                             
  - Added rotate dispatch branch in tool runner.                                                                                                                
  - Implemented rotatePDF(...):                                                                                                                                 
      - Reads only pdfRotateConfig                                                                                                                              
      - Applies rotation via pdf-lib                                                                                                                            
      - Supports page selection parsing                                                                                                                         
  - Implemented parsePageSelection(...) helper:                                                                                                                 
      - Supports comma-separated pages and ranges                                                                                                               
      - Falls back to all pages if empty/invalid                                                                                                                
                                                                                                                                                                
  Why                                                                                                                                                           
                                                                                                                                                                
  - Eliminates state inconsistency (rotationAngle vs pdfRotateAngle / rotationAngleOption).                                                                     
  - Removes duplicate/parallel rotate config behavior.                                                                                                          
  - Guarantees processing uses exactly the settings set in UI.                                                                                                  
                                                                                                                                                                
  Acceptance criteria                                                                                                                                           
                                                                                                                                                                
  - One canonical rotate config state: pdfRotateConfig only.                                                                                                    
  - No duplicate rotate config handling paths.                                                                                                                  
  - Rotate processing consumes exactly what UI sets.                                                                                                            
                                                                                                                                                                
  Manual verification                                                                                                                                           
                                                                                                                                                                
  1. Start app and open /tool/pdf-rotate.                                                                                                                       
  2. Upload a multi-page PDF.                                                                                                                                   
  3. Set angle and pages (2,4-5 or empty for all).                                                                                                              
  4. Process and download.                                                                                                                                      
  5. Confirm rotated pages and angle match UI settings exactly.
  
  issue #325 fixed