### PR TITLE
Make PDF compression level selector functional

### DIFF
--- a/app/tool/[id]/processing/page.tsx
+++ b/app/tool/[id]/processing/page.tsx
@@ -26,6 +26,12 @@ type CompressionApiResponse = {
   targetBytes: number | null;
   originalBytes: number;
   compressedBytes: number;
+  settings?: {
+    requestedLevel: "low" | "medium" | "high";
+    appliedLevel: "low" | "medium" | "high";
+    useObjectStreams: boolean;
+    rewriteMode: "direct" | "rebuilt";
+  };
   outputBase64: string;
   error?: string;
 };
@@ -66,6 +72,13 @@ export default function ProcessingPage() {
   const [compressionTargetStatus, setCompressionTargetStatus] = useState<
     "no_target" | "target_reached" | "target_unreachable"
   >("no_target");
+  const [compressionLevelUsed, setCompressionLevelUsed] = useState<"low" | "medium" | "high">(
+    "medium",
+  );
+  const [compressionRewriteMode, setCompressionRewriteMode] = useState<"direct" | "rebuilt">(
+    "direct",
+  );
+  const [compressionUsesObjectStreams, setCompressionUsesObjectStreams] = useState(false);
 
   useEffect(() => {
     return () => {
@@ -190,6 +203,9 @@ export default function ProcessingPage() {
     const finalBytes = decodeBase64Payload(result.outputBase64);
     setCompressionTargetStatus(result.status || "no_target");
     setCompressionTargetBytes(result.targetBytes);
+    setCompressionLevelUsed(result.settings?.appliedLevel || level);
+    setCompressionRewriteMode(result.settings?.rewriteMode || "direct");
+    setCompressionUsesObjectStreams(Boolean(result.settings?.useObjectStreams));
 
     setStage("Finalizing...");
     setProgress(85);
@@ -859,6 +875,9 @@ export default function ProcessingPage() {
 
         {toolId === "pdf-compress" && originalSize && compressedSize && (
           <div className="mt-6 p-4 bg-gray-100 rounded-lg text-sm">
+            <p>Compression level: {compressionLevelUsed}</p>
+            <p>Processing mode: {compressionRewriteMode}</p>
+            <p>Object streams: {compressionUsesObjectStreams ? "enabled" : "disabled"}</p>
             <p>Original: {(originalSize / 1024 / 1024).toFixed(2)} MB</p>
             <p>Compressed: {(compressedSize / 1024 / 1024).toFixed(2)} MB</p>
             <p className="font-semibold text-green-600">


### PR DESCRIPTION
This PR makes compressionLevel actually affect PDF compression output and surfaces applied settings in the processing result.                
                                                                                                                                               
  What changed                                                                                                                                 
                                                                                                                                               
  - Updated compression pipeline in app/api/compress/route.ts:                                                                                 
      - Added multiple compression strategies per level (direct vs rebuilt rewrite, object streams on/off).                                    
      - Changed candidate selection to be level-driven:                                                                                        
          - high picks most aggressive (smallest output),                                                                                      
          - medium picks middle,                                                                                                               
          - low picks least aggressive (larger output).                                                                                        
  - Added settings to compression API response:                                                                                                
      - requestedLevel, appliedLevel, rewriteMode, useObjectStreams.                                                                           
  - Updated app/tool/[id]/processing/page.tsx:                                                                                                 
      - Consumes returned settings.                                                                                                            
      - Displays applied compression settings in the result card.                                                                              
                                                                                                                                               
  Acceptance criteria mapping                                                                                                                  
                                                                                                                                               
  - Low/medium/high produce measurably different outputs:                                                                                      
      - Achieved via explicit level-based candidate selection across distinct compression profiles.                                            
  - Selected level is reflected in processing settings:                                                                                        
      - Achieved via API settings payload + UI display on processing result page.                                                              
                                                                                                                                               
  Manual verification                                                                                                                          
                                                                                                                                               
  1. Upload same PDF 3 times with Low, Medium, High.                                                                                           
  2. Confirm output sizes differ (typically High <= Medium <= Low).                                                                            
  3. Confirm result card shows:                                                                                                                
      - Compression level                                                                                                                      
      - Processing mode                                                                                                                        
      - Object streams
      
issue #356 