### PR TITLE
Fix PDF tool option wiring regressions and restore OCR result visibility

### DIFF
--- a/app/tool/[id]/processing/page.tsx
+++ b/app/tool/[id]/processing/page.tsx
@@ -21,8 +21,6 @@ type DownloadItem = {
   name: string;
 };
 
-<<<<<<< HEAD
-=======
 type CompressionApiResponse = {
   status: "no_target" | "target_reached" | "target_unreachable";
   targetBytes: number | null;
@@ -37,8 +35,6 @@ type CompressionApiResponse = {
   outputBase64: string;
   error?: string;
 };
-
->>>>>>> upstream/main
 const SUPPORTED_PROCESSING_TOOLS = new Set([
   "ocr",
   "pdf-protect",
@@ -90,15 +86,6 @@ export default function ProcessingPage() {
     };
   }, [downloadItems]);
 
-<<<<<<< HEAD
-  useEffect(() => {
-    return () => {
-      downloadItems.forEach((item) => URL.revokeObjectURL(item.url));
-    };
-  }, [downloadItems]);
-
-=======
->>>>>>> upstream/main
   useEffect(() => {
     const run = async () => {
       const stored = getStoredFiles() as StoredFile[];
@@ -181,28 +168,6 @@ export default function ProcessingPage() {
     setStage("Preparing file...");
     setProgress(20);
 
-<<<<<<< HEAD
-    const structuralSource = new Uint8Array(sourceBytes);
-    structuralSource.set(sourceBytes);
-
-    const level = getCompressionLevelFromState();
-    setStage(`Compressing PDF (${level})...`);
-    setProgress(45);
-
-    const compressed =
-      level === "low"
-        ? await structuralCompressPdf(structuralSource)
-        : await rasterCompressPdf(file, new Uint8Array(sourceBytes), level);
-
-    const finalBytes =
-      compressed.length < sourceBytes.length
-        ? compressed
-        : await structuralCompressPdf(structuralSource);
-
-    setStage("Finalizing...");
-    setProgress(85);
-    setCompressedSize(finalBytes.length);
-=======
     const level = getCompressionLevelFromState();
     const targetBytes = getCompressionTargetBytesFromState();
     setCompressionTargetBytes(targetBytes);
@@ -245,7 +210,6 @@ export default function ProcessingPage() {
     setStage("Finalizing...");
     setProgress(85);
     setCompressedSize(result.compressedBytes || finalBytes.length);
->>>>>>> upstream/main
     setDownloadItems([
       {
         url: makeBlobUrl(finalBytes, "application/pdf"),
@@ -696,87 +660,6 @@ export default function ProcessingPage() {
     setStatus("done");
   };
 
-<<<<<<< HEAD
-  const structuralCompressPdf = async (bytes: Uint8Array) => {
-    const sourcePdf = await PDFDocument.load(bytes);
-    const outputPdf = await PDFDocument.create();
-    const pages = await outputPdf.copyPages(sourcePdf, sourcePdf.getPageIndices());
-    pages.forEach((page) => outputPdf.addPage(page));
-
-    return outputPdf.save({
-      useObjectStreams: true,
-      addDefaultPage: false,
-      objectsPerTick: 20,
-    });
-  };
-
-  const rasterCompressPdf = async (
-    file: StoredFile,
-    bytes: Uint8Array,
-    level: "medium" | "high"
-  ) => {
-    const loadingTask = await loadPdfJsDocument(bytes, file.name);
-    const inputPdf = loadingTask;
-    const outputPdf = await PDFDocument.create();
-    const renderScale = level === "high" ? 1.0 : 1.25;
-    const jpegQuality = level === "high" ? 0.55 : 0.72;
-
-    const canvas = document.createElement("canvas");
-    const context = canvas.getContext("2d", { alpha: false });
-    if (!context) {
-      throw new Error("Canvas context is unavailable.");
-    }
-
-    for (let pageNumber = 1; pageNumber <= inputPdf.numPages; pageNumber++) {
-      setStage(`Compressing page ${pageNumber}/${inputPdf.numPages}...`);
-      setProgress(45 + Math.round((pageNumber / inputPdf.numPages) * 35));
-
-      const page = await inputPdf.getPage(pageNumber);
-      const baseViewport = page.getViewport({ scale: 1 });
-      const renderViewport = page.getViewport({ scale: renderScale });
-
-      canvas.width = Math.max(1, Math.floor(renderViewport.width));
-      canvas.height = Math.max(1, Math.floor(renderViewport.height));
-      context.fillStyle = "#ffffff";
-      context.fillRect(0, 0, canvas.width, canvas.height);
-
-      await page.render({
-        canvasContext: context,
-        viewport: renderViewport,
-      }).promise;
-
-      const jpegBlob = await new Promise<Blob>((resolve, reject) => {
-        canvas.toBlob(
-          (blob) => (blob ? resolve(blob) : reject(new Error("Image encoding failed"))),
-          "image/jpeg",
-          jpegQuality
-        );
-      });
-
-      const jpgBytes = new Uint8Array(await jpegBlob.arrayBuffer());
-      const image = await outputPdf.embedJpg(jpgBytes);
-      const outPage = outputPdf.addPage([baseViewport.width, baseViewport.height]);
-      outPage.drawImage(image, {
-        x: 0,
-        y: 0,
-        width: baseViewport.width,
-        height: baseViewport.height,
-      });
-    }
-
-    canvas.width = 0;
-    canvas.height = 0;
-    await inputPdf.destroy();
-
-    return outputPdf.save({
-      useObjectStreams: true,
-      addDefaultPage: false,
-      objectsPerTick: 20,
-    });
-  };
-
-=======
->>>>>>> upstream/main
   const readPdfBytes = async (file: StoredFile) => {
     const primary = await readRawBytes(file);
     try {
@@ -852,8 +735,6 @@ export default function ProcessingPage() {
     return "medium";
   };
 
-<<<<<<< HEAD
-=======
   const getCompressionTargetBytesFromState = () => {
     const raw = localStorage.getItem("compressionTargetBytes") || localStorage.getItem("targetBytes");
     if (!raw) return null;
@@ -861,8 +742,6 @@ export default function ProcessingPage() {
     if (!Number.isFinite(parsed) || parsed <= 0) return null;
     return parsed;
   };
-
->>>>>>> upstream/main
   const parsePageSelection = (input: string, totalPages: number) => {
     const allPages = new Set<number>();
     for (let i = 1; i <= totalPages; i++) allPages.add(i);
@@ -1033,10 +912,15 @@ export default function ProcessingPage() {
         )}
 
         {toolId === "ocr" && (
-          <button onClick={copyText} className="mt-4 px-6 py-3 border rounded-lg">
-            <Copy className="inline w-4 h-4 mr-2" />
-            {copied ? "Copied!" : "Copy Text"}
-          </button>
+          <div className="mt-4 max-w-3xl">
+            <div className="rounded-lg border bg-gray-50 p-4 text-left text-sm whitespace-pre-wrap max-h-72 overflow-auto">
+              {text || "No text was extracted."}
+            </div>
+            <button onClick={copyText} className="mt-4 px-6 py-3 border rounded-lg">
+              <Copy className="inline w-4 h-4 mr-2" />
+              {copied ? "Copied!" : "Copy Text"}
+            </button>
+          </div>
         )}
       </div>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@types/react": "^19.2.13",
         "@types/react-dom": "^19.2.3",
         "babel-plugin-react-compiler": "1.0.0",
-        "eslint": "^9",
+        "eslint": "^9.39.2",
         "eslint-config-next": "16.1.4",
         "tailwindcss": "^4",
         "typescript": "^5"
@@ -85,7 +85,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -312,7 +311,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1988,7 +1986,6 @@
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2048,7 +2045,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -2557,7 +2553,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2844,7 +2839,6 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -2950,7 +2944,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3557,7 +3550,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3743,7 +3735,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6041,7 +6032,6 @@
       "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
       "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@pdf-lib/standard-fonts": "^1.0.0",
         "@pdf-lib/upng": "^1.0.1",
@@ -6190,7 +6180,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6200,7 +6189,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7034,7 +7022,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7203,7 +7190,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7546,7 +7532,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/react": "^19.2.13",
     "@types/react-dom": "^19.2.3",
     "babel-plugin-react-compiler": "1.0.0",
-    "eslint": "^9",
+    "eslint": "^9.39.2",
     "eslint-config-next": "16.1.4",
     "tailwindcss": "^4",
     "typescript": "^5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,7 +85,7 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       eslint:
-        specifier: ^9
+        specifier: ^9.39.2
         version: 9.39.2(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.1.4


### PR DESCRIPTION
Summary                                                                                                                                                       
  This PR fixes upload-to-processing wiring gaps in DocuHub where several PDF tools expected config from state/localStorage but the upload UI did not expose    
  corresponding controls. It also restores OCR output visibility in the completion screen.                                                                      
                                                                                                                                                                
  What’s Fixed                                                                                                                                                  
                                                                                                                                                                
  - Added missing upload controls and persistence wiring in app/tool/[id]/page.tsx:                                                                             
      - pdf-protect: password input                                                                                                                             
      - pdf-password-remover: password input                                                                                                                    
      - pdf-delete-pages: page selection input (pdfDeletePages)                                                                                                 
      - pdf-page-reorder: page order input (pdfReorderPages)                                                                                                    
      - pdf-watermark: text/rotation/opacity (watermarkText, watermarkRotation, watermarkOpacity)                                                               
      - pdf-extract-images: format selector (pdfExtractImageFormat)                                                                                             
      - pdf-page-numbers: format/font size (pageNumberFormat, pageNumberFontSize)                                                                               
      - pdf-rotate: angle/pages (pdfRotateConfig)                                                                                                               
  - Added required-input guards and disabled state for blocked flows (protect, password-remover, delete-pages, page-reorder, watermark).                        
  - Restored loading of saved option values from localStorage for the above tools.                                                                              
  - Cleaned merge-conflict artifacts in:                                                                                                                        
      - app/tool/[id]/page.tsx                                                                                                                                  
      - app/tool/[id]/processing/page.tsx                                                                                                                       
  - OCR completion UI now renders extracted text (readonly preview) and keeps Copy Text.                                                                        
                                                                                                                                                                
 