### PR TITLE
 Fix dashboard tool name formatting for multi-hyphen IDs

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -301,7 +301,7 @@ export default function Dashboard() {
                     href={`/tool/${lastTool}`}
                     className="text-lg font-bold text-foreground hover:text-primary transition-colors flex items-center gap-2"
                   >
-                    {lastTool.replace("-", " ").toUpperCase()}
+                    {lastTool.replaceAll("-", " ").toUpperCase()}
                     <ArrowRight className="w-4 h-4" />
                   </Link>
                 </div>
@@ -362,7 +362,7 @@ export default function Dashboard() {
                       className="glass-card p-5 flex flex-col justify-between group"
                     >
                       <span className="font-bold text-foreground group-hover:text-primary transition-colors">
-                        {tool.replace("-", " ").toUpperCase()}
+                        {tool.replaceAll("-", " ").toUpperCase()}
                       </span>
                       <span className="text-xs text-muted-foreground mt-2">
                         {count} sessions


### PR DESCRIPTION
Summary                                                                                                                                                       
                                                                                                                                                                
  - Replaced single-hyphen substitution with global substitution when rendering tool labels.                                                                    
  - This fixes formatting in:                                                                                                                                   
      - Resume your work                                                                                                                                        
      - Most Used Tools                                                                                                                                         

  Changes                                                                                                                                                       
                                                                                                                                                                
  - DocuHub/app/dashboard/page.tsx:304                                                                                                                          
      - lastTool.replace("-", " ") → lastTool.replaceAll("-", " ")                                                                                              
  - DocuHub/app/dashboard/page.tsx:365                                                                                                                          
      - tool.replace("-", " ") → tool.replaceAll("-", " ")                                                                                                      
                                                                                                                                                                
  Why                                                                                                                                                           
  Tool IDs like pdf-page-reorder were rendering as PDF PAGE-REORDER instead of PDF PAGE REORDER.                                                                
                                                                                                                                                                
  Verification                                                                                                                                                  
                                                                                                                                                                
  - Open /dashboard                                                                                                                                             
  - Ensure entries with multi-hyphen IDs display with all spaces in both sections above. 
  
  issue #399 